### PR TITLE
RDMA/bnxt_re: Print the HW QP id on failure to destroy

### DIFF
--- a/drivers/infiniband/hw/bnxt_re/ib_verbs.c
+++ b/drivers/infiniband/hw/bnxt_re/ib_verbs.c
@@ -796,7 +796,8 @@ int bnxt_re_destroy_qp(struct ib_qp *ib_qp, struct ib_udata *udata)
 
 	rc = bnxt_qplib_destroy_qp(&rdev->qplib_res, &qp->qplib_qp);
 	if (rc) {
-		ibdev_err(&rdev->ibdev, "Failed to destroy HW QP");
+		ibdev_err(&rdev->ibdev, "Failed to destroy HW QP 0x%x",
+			  qp->qplib_qp.id);
 		return rc;
 	}
 


### PR DESCRIPTION
Print the HW QP id whenever the destroy fails

Fixes: 6ccad8483b28 ("RDMA/bnxt_re: use ibdev based message printing functions")
Signed-off-by: Naresh Kumar PBS <nareshkumar.pbs@broadcom.com>