### PR TITLE
RDMA/bnxt_re: Re-create Shadow AH during a mac address change

### DIFF
--- a/drivers/infiniband/hw/bnxt_re/bnxt_re.h
+++ b/drivers/infiniband/hw/bnxt_re/bnxt_re.h
@@ -132,6 +132,7 @@ struct bnxt_re_dev {
 	struct list_head		list;
 	unsigned long			flags;
 #define BNXT_RE_FLAG_NETDEV_REGISTERED		0
+#define BNXT_RE_FLAG_IBDEV_REGISTERED           1
 #define BNXT_RE_FLAG_GOT_MSIX			2
 #define BNXT_RE_FLAG_HAVE_L2_REF		3
 #define BNXT_RE_FLAG_RCFW_CHANNEL_EN		4

--- a/drivers/infiniband/hw/bnxt_re/ib_verbs.h
+++ b/drivers/infiniband/hw/bnxt_re/ib_verbs.h
@@ -215,4 +215,5 @@ int bnxt_re_mmap(struct ib_ucontext *context, struct vm_area_struct *vma);
 
 unsigned long bnxt_re_lock_cqs(struct bnxt_re_qp *qp);
 void bnxt_re_unlock_cqs(struct bnxt_re_qp *qp, unsigned long flags);
+void bnxt_re_update_shadow_ah(struct bnxt_re_dev *rdev);
 #endif /* __BNXT_RE_IB_VERBS_H__ */

--- a/drivers/infiniband/hw/bnxt_re/main.c
+++ b/drivers/infiniband/hw/bnxt_re/main.c
@@ -1323,6 +1323,7 @@ static int bnxt_re_ib_init(struct bnxt_re_dev *rdev)
 	ib_get_eth_speed(&rdev->ibdev, 1, &rdev->active_speed,
 			 &rdev->active_width);
 	set_bit(BNXT_RE_FLAG_ISSUE_ROCE_STATS, &rdev->flags);
+	set_bit(BNXT_RE_FLAG_IBDEV_REGISTERED, &rdev->flags);
 
 	event = netif_running(rdev->netdev) && netif_carrier_ok(rdev->netdev) ?
 		IB_EVENT_PORT_ACTIVE : IB_EVENT_PORT_ERR;
@@ -1719,6 +1720,12 @@ static int bnxt_re_netdev_event(struct notifier_block *notifier,
 		ib_unregister_device_queued(&rdev->ibdev);
 		break;
 
+	case NETDEV_CHANGEADDR:
+		/* MAC addr change event */
+		if (!bnxt_qplib_is_chip_gen_p5(rdev->chip_ctx) &&
+		    test_bit(BNXT_RE_FLAG_IBDEV_REGISTERED, &rdev->flags))
+			bnxt_re_update_shadow_ah(rdev);
+		break;
 	default:
 		sch_work = true;
 		break;
@@ -1786,7 +1793,9 @@ static void __exit bnxt_re_mod_exit(void)
 		 * shall be removed before the PF during the call of
 		 * ib_unregister_driver.
 		 */
-		if (rdev->is_virtfn)
+		if (rdev->is_virtfn &&
+		    (test_and_clear_bit(BNXT_RE_FLAG_IBDEV_REGISTERED,
+				       &rdev->flags)))
 			ib_unregister_device(&rdev->ibdev);
 	}
 	ib_unregister_driver(RDMA_DRIVER_BNXT_RE);

--- a/drivers/infiniband/hw/bnxt_re/qplib_sp.c
+++ b/drivers/infiniband/hw/bnxt_re/qplib_sp.c
@@ -544,21 +544,23 @@ int bnxt_qplib_create_ah(struct bnxt_qplib_res *res, struct bnxt_qplib_ah *ah,
 	return 0;
 }
 
-void bnxt_qplib_destroy_ah(struct bnxt_qplib_res *res, struct bnxt_qplib_ah *ah,
-			   bool block)
+int bnxt_qplib_destroy_ah(struct bnxt_qplib_res *res, struct bnxt_qplib_ah *ah,
+			  bool block)
 {
 	struct bnxt_qplib_rcfw *rcfw = res->rcfw;
 	struct cmdq_destroy_ah req;
 	struct creq_destroy_ah_resp resp;
 	u16 cmd_flags = 0;
+	int rc;
 
 	/* Clean up the AH table in the device */
 	RCFW_CMD_PREP(req, DESTROY_AH, cmd_flags);
 
 	req.ah_cid = cpu_to_le32(ah->id);
 
-	bnxt_qplib_rcfw_send_message(rcfw, (void *)&req, (void *)&resp, NULL,
-				     block);
+	rc = bnxt_qplib_rcfw_send_message(rcfw, (void *)&req, (void *)&resp,
+					  NULL, block);
+	return rc;
 }
 
 /* MRW */

--- a/drivers/infiniband/hw/bnxt_re/qplib_sp.h
+++ b/drivers/infiniband/hw/bnxt_re/qplib_sp.h
@@ -245,8 +245,8 @@ int bnxt_qplib_set_func_resources(struct bnxt_qplib_res *res,
 				  struct bnxt_qplib_ctx *ctx);
 int bnxt_qplib_create_ah(struct bnxt_qplib_res *res, struct bnxt_qplib_ah *ah,
 			 bool block);
-void bnxt_qplib_destroy_ah(struct bnxt_qplib_res *res, struct bnxt_qplib_ah *ah,
-			   bool block);
+int bnxt_qplib_destroy_ah(struct bnxt_qplib_res *res, struct bnxt_qplib_ah *ah,
+			  bool block);
 int bnxt_qplib_alloc_mrw(struct bnxt_qplib_res *res,
 			 struct bnxt_qplib_mrw *mrw);
 int bnxt_qplib_dereg_mrw(struct bnxt_qplib_res *res, struct bnxt_qplib_mrw *mrw,


### PR DESCRIPTION
Shadow AH is used for loopback shadow qp traffic for non
p5 adapters. Adding a code to destroy the current Shadow
AH and create a new AH using the new MAC address. The
update is handled from the rtnl_lock to avoid any device
removal while re-creating the AH.

Signed-off-by: Naresh Kumar PBS <nareshkumar.pbs@broadcom.com>