### PR TITLE
RDMA/bnxt_re: Trim the QP mtu if it is higher than L2 MTU

### DIFF
--- a/drivers/infiniband/hw/bnxt_re/roce_hsi.h
+++ b/drivers/infiniband/hw/bnxt_re/roce_hsi.h
@@ -2869,7 +2869,9 @@ struct creq_query_func_resp_sb {
 	__le32 max_gid;
 	__le32 tqm_alloc_reqs[12];
 	__le32 max_dpi;
-	__le32 reserved_32;
+	u8 max_sge_var_wqe;
+	u8 reserved_8;
+	__le16 max_inline_data_var_wqe;
 };
 
 /* Set resources command response (16 bytes) */


### PR DESCRIPTION
Gen P5 chip allow sending roce packets bigger than L2 MTU.
But at the responder the packets are dropped if mismatch is
detected in the incoming packet size and the interface MTU.
If this is attempted by a malicious or badly written code
the chip drops incoming packets and corresponding rx error
counter is incremented. Since there is no response from
the responder QP the requester QP moves to ACK-Timeout
state.

Fixing the QP mtu setting to trim the qp-mtu to the lower
bound of L2 MTU during modify-qp from init to rtr.

Temporarily driver would fail the modify-request with mis-
matching MTU due to unavilability of a method which would
tell user qp about trimmed MTU.

Moved the mtu initialization code to separate inline
functions for ease of flow.

Signed-off-by: Bharat Gooty <bharat.gooty@broadcom.com>