### PR TITLE
RDMA/bnxt_re: Disable/kill tasklet only if it is enabled

### DIFF
--- a/drivers/infiniband/hw/bnxt_re/main.c
+++ b/drivers/infiniband/hw/bnxt_re/main.c
@@ -335,15 +335,21 @@ static void bnxt_re_start_irq(void *handle, struct bnxt_msix_entry *ent)
 	for (indx = 0; indx < rdev->num_msix; indx++)
 		rdev->msix_entries[indx].vector = ent[indx].vector;
 
-	bnxt_qplib_rcfw_start_irq(rcfw, msix_ent[BNXT_RE_AEQ_IDX].vector,
-				  false);
+	rc = bnxt_qplib_rcfw_start_irq(rcfw, msix_ent[BNXT_RE_AEQ_IDX].vector,
+				       false);
+	if (rc) {
+		ibdev_warn(&rdev->ibdev, "Failed to reinit CREQ\n");
+		return;
+	}
 	for (indx = BNXT_RE_NQ_IDX ; indx < rdev->num_msix; indx++) {
 		nq = &rdev->nq[indx - 1];
 		rc = bnxt_qplib_nq_start_irq(nq, indx - 1,
 					     msix_ent[indx].vector, false);
-		if (rc)
+		if (rc) {
 			ibdev_warn(&rdev->ibdev, "Failed to reinit NQ index %d\n",
 				   indx - 1);
+			return;
+		}
 	}
 }
 

--- a/drivers/infiniband/hw/bnxt_re/qplib_fp.c
+++ b/drivers/infiniband/hw/bnxt_re/qplib_fp.c
@@ -409,16 +409,17 @@ void bnxt_qplib_nq_stop_irq(struct bnxt_qplib_nq *nq, bool kill)
 	if (!nq->requested)
 		return;
 
-	tasklet_disable(&nq->nq_tasklet);
+	nq->requested = false;
 	/* Mask h/w interrupt */
 	bnxt_qplib_ring_nq_db(&nq->nq_db.dbinfo, nq->res->cctx, false);
 	/* Sync with last running IRQ handler */
 	synchronize_irq(nq->msix_vec);
+	free_irq(nq->msix_vec, nq);
+	irq_set_affinity_hint(nq->msix_vec, NULL);
+	/* Cleanup Tasklet */
 	if (kill)
 		tasklet_kill(&nq->nq_tasklet);
-	irq_set_affinity_hint(nq->msix_vec, NULL);
-	free_irq(nq->msix_vec, nq);
-	nq->requested = false;
+	tasklet_disable(&nq->nq_tasklet);
 }
 
 void bnxt_qplib_disable_nq(struct bnxt_qplib_nq *nq)

--- a/drivers/infiniband/hw/bnxt_re/qplib_rcfw.c
+++ b/drivers/infiniband/hw/bnxt_re/qplib_rcfw.c
@@ -632,16 +632,16 @@ void bnxt_qplib_rcfw_stop_irq(struct bnxt_qplib_rcfw *rcfw, bool kill)
 
 	if (!creq->requested)
 		return;
-	tasklet_disable(&creq->creq_tasklet);
+	creq->requested = false;
 	/* Mask h/w interrupts */
 	bnxt_qplib_ring_nq_db(&creq->creq_db.dbinfo, rcfw->res->cctx, false);
 	/* Sync with last running IRQ-handler */
 	synchronize_irq(creq->msix_vec);
+	free_irq(creq->msix_vec, rcfw);
+	/* Cleanup Tasklet */
 	if (kill)
 		tasklet_kill(&creq->creq_tasklet);
-
-	free_irq(creq->msix_vec, rcfw);
-	creq->requested = false;
+	tasklet_disable(&creq->creq_tasklet);
 }
 
 void bnxt_qplib_disable_rcfw_channel(struct bnxt_qplib_rcfw *rcfw)

--- a/drivers/infiniband/hw/bnxt_re/qplib_rcfw.h
+++ b/drivers/infiniband/hw/bnxt_re/qplib_rcfw.h
@@ -112,7 +112,7 @@ struct bnxt_qplib_crsbe {
 #define CREQ_CMP_VALID(hdr, raw_cons, cp_bit)			\
 	(!!((hdr)->v & CREQ_BASE_V) ==				\
 	   !((raw_cons) & (cp_bit)))
-#define CREQ_ENTRY_POLL_BUDGET		0x100
+#define CREQ_ENTRY_POLL_BUDGET		8
 
 /* HWQ */
 typedef int (*aeq_handler_t)(struct bnxt_qplib_rcfw *, void *, void *);
@@ -162,6 +162,8 @@ struct bnxt_qplib_creq_db {
 };
 
 struct bnxt_qplib_creq_stat {
+	u64	creq_arm_count;
+	u64	creq_tasklet_schedule_count;
 	u64	creq_qp_event_processed;
 	u64	creq_func_event_processed;
 };


### PR DESCRIPTION
When the ulp hook to start the IRQ fails because the rings
are not available, tasklets are not enabled. In this case when
the driver is unloaded, driver calls CREQ tasklet_kill. This
causes an indefinite hang as the tasklet is not enabled.

Driver shouldn't call tasklet_kill if it is not enabled. So
using the creq->requested and nq->requested flags to identify
if both tasklets/irqs are registered. Checking this flag while
scheduling the tasklet from ISR. Also, added a cleanup for
disabling tasklet, in case request_irq fails during start_irq.

Check for return value for bnxt_qplib_rcfw_start_irq and in case
the bnxt_qplib_rcfw_start_irq fails, return bnxt_re_start_irq
without attempting to start NQ IRQs.

Signed-off-by: Naresh Kumar PBS <nareshkumar.pbs@broadcom.com>